### PR TITLE
Use a Clojurescript macro to make EUI theme CSS and JSON values available

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ What it looks like to use this library:
 
 We are also able to overwrite certain components without the end-developer's knowledge which keeps the experience unified. For example we needed to port the text field components so they would compatible with Reagent's async-rendering. Those components live in the overrwrites directory.
 
+## Theming
+
+To keep things self contained within this library, the `eui.theme` namespace has a `themes` variable which contains the raw CSS and an JSON->EDN conversion of the variables for a given theme. In your project you may want to chuck the `(-> themes :dark :css)` into a `<style></style>` and then use the `(-> themes :dark :values)` map inside of components co-located styling. I use this strategy in place of externally requiring the EUI CSS file from a `public` directory on my server.
+
 ## Note on Icons
 
 The Google Closure Compiler, advanced as it is, does not currently support async Javascript imports which EUI utilizes heavily for rendering icons in components. The work around involves calling their escape-hatch `appendIconComponentCache` function with a resolver map like:

--- a/overwrites/theme.clj
+++ b/overwrites/theme.clj
@@ -1,0 +1,13 @@
+(ns eui.theme
+  (:require [cheshire.core :as json]))
+
+(defmacro load-file
+  [path]
+  (-> (str "node_modules/@elastic/eui/" path)
+      (slurp)))
+
+(defmacro load-json
+  [path]
+  (-> (str "node_modules/@elastic/eui/" path)
+      (slurp)
+      (json/parse-string)))

--- a/overwrites/theme.cljs
+++ b/overwrites/theme.cljs
@@ -1,0 +1,11 @@
+(ns eui.theme
+  (:require-macros [eui.theme :refer [load-file load-json]]))
+
+(def themes
+  {:light
+   {:css (load-file "dist/eui_theme_amsterdam_light.min.css")
+    :values (load-json "dist/eui_theme_amsterdam_light.json")}
+
+   :dark
+   {:css (load-file "dist/eui_theme_amsterdam_dark.min.css")
+    :values (load-json "dist/eui_theme_amsterdam_dark.json")}})

--- a/src/eui/theme.clj
+++ b/src/eui/theme.clj
@@ -1,0 +1,13 @@
+(ns eui.theme
+  (:require [cheshire.core :as json]))
+
+(defmacro load-file
+  [path]
+  (-> (str "node_modules/@elastic/eui/" path)
+      (slurp)))
+
+(defmacro load-json
+  [path]
+  (-> (str "node_modules/@elastic/eui/" path)
+      (slurp)
+      (json/parse-string)))

--- a/src/eui/theme.cljs
+++ b/src/eui/theme.cljs
@@ -1,0 +1,11 @@
+(ns eui.theme
+  (:require-macros [eui.theme :refer [load-file load-json]]))
+
+(def themes
+  {:light
+   {:css (load-file "dist/eui_theme_amsterdam_light.min.css")
+    :values (load-json "dist/eui_theme_amsterdam_light.json")}
+
+   :dark
+   {:css (load-file "dist/eui_theme_amsterdam_dark.min.css")
+    :values (load-json "dist/eui_theme_amsterdam_dark.json")}})


### PR DESCRIPTION
Before this change updating EUI required manually copying the theme CSS files into some server public directory. This change makes the CSS and theme variables available through the `eui.theme` namespace.

https://github.com/elastic/infra/issues/23160